### PR TITLE
Add copilot

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -72,6 +72,7 @@
 			},
 			"extensions": [
 				"James-Yu.latex-workshop",
+				"GitHub.copilot",
 				// Remove the line below if you do not want Live-Collaboration Feature
 				"ms-vsliveshare.vsliveshare",
 				// Uncomment the line below if you do not want LanguageTool Support


### PR DESCRIPTION
Consider adding GitHub Copilot to the extensions. Among other reasons, it's very nice for writing mathematical formulas.
With Copilot enabled, type
```the Navier-Stokes equations are```
or
```the normal distribution is defined as```
and it will complete the LaTeX formula.