### PR TITLE
automatically wrap text

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -48,6 +48,7 @@
 	"latex-workshop.latex.pdfWatch.delay": 500,
 	//"latex-workshop.latex.watch.delay": 500, // Deprecated. See here: https://github.com/sanjib-sen/WebLaTex/issues/8
 	"latex-workshop.codespaces.portforwarding.openDelay": 20000,
+	"editor.wordWrap": "on",
 	"grammarly.files.include": [
 		"**/*.tex"
 	],


### PR DESCRIPTION
Enable dynamic text wrapping by setting VS Code's "editor.wordWrap" to "on", allowing text to reflow based on the window size. This improves readability in LaTeX documents.